### PR TITLE
Fix Ground and Supply pins not being set on Circuit Chips

### DIFF
--- a/src/chip/chip.rs
+++ b/src/chip/chip.rs
@@ -43,7 +43,7 @@ pub struct SupplyChip {
     value: u8,
 }
 impl SupplyChip {
-    pub fn new() -> Self { Self { value: 1 } }
+    pub fn new() -> Self { Self { value: 0 } }
     pub fn turn_on(&mut self) { self.value = 1; }
     pub fn turn_off(&mut self) { self.value = 0; }
 }

--- a/src/chip/circuit.rs
+++ b/src/chip/circuit.rs
@@ -47,6 +47,13 @@ impl Circuit {
         }
         self.chips.get_mut(&input_chip_id).unwrap().write_pin(0, value);
     }
+    
+    pub fn get_supply_ids(&self) -> Vec<usize> {
+        self.description.chip_types.iter()
+            .filter(|(_, chip_type)| chip_type == &&ChipType::Supply)
+            .map(|(id, _)| *id)
+            .collect()
+    }
 
     pub fn set_supply(&mut self, supply_chip_id: usize, value: u8) {
         if self.description.chip_types.get(&supply_chip_id) != Some(&ChipType::Supply) {
@@ -76,6 +83,25 @@ impl Circuit {
         }
         self.back_links.remove(&target);
     }
+    
+    pub fn get_chip_pin_states(&self) -> HashMap<ChipAndPin, u8> {
+        let mut pin_states: HashMap<ChipAndPin, u8> = HashMap::new();
+        for (id, chip) in &self.chips {
+            for pin in chip.get_layout().ground_pins {
+                pin_states.insert(chip_pin!(*id, pin), chip.read_pin(pin));
+            }
+            for pin in chip.get_layout().supply_pins {
+                pin_states.insert(chip_pin!(*id, pin), chip.read_pin(pin));
+            }
+            for pin in chip.get_layout().input_pins {
+                pin_states.insert(chip_pin!(*id, pin), chip.read_pin(pin));
+            }
+            for pin in chip.get_layout().output_pins {
+                pin_states.insert(chip_pin!(*id, pin), chip.read_pin(pin));
+            }
+        }
+        pin_states
+    }
 
     fn get_input_ids(&self) -> Vec<usize> {
         self.description
@@ -87,10 +113,16 @@ impl Circuit {
     }
     
     fn get_input_values_for_chip(&self, index: &usize) -> HashMap<usize, u8> {
-        let input_pins = self.chips.get(index).unwrap().get_layout().input_pins;
+        let layout = self.chips.get(index).unwrap().get_layout();
+        let all_inputs: Vec<Vec<usize>> = vec![layout.ground_pins, layout.supply_pins, layout.input_pins];
+        let all_pins: Vec<usize> = all_inputs.iter()
+            .flat_map(|v| v.iter())
+            .map(|v| *v)
+            .collect();
+
         let mut inputs = HashMap::new();
         
-        for pin_idx in input_pins {
+        for pin_idx in all_pins {
             let pin = chip_pin!(*index, pin_idx);
             let back_link_option = self.back_links.get(&pin);
 

--- a/src/chip/tests/test_chip.rs
+++ b/src/chip/tests/test_chip.rs
@@ -18,8 +18,15 @@ fn given_ground_then_has_1_output_pin() {
 }
 
 #[test]
-fn given_supply_then_output_1() {
+fn given_supply_when_new_then_output_0() {
     let chip = SupplyChip::new();
+    assert_eq!(chip.read_pin(0), 0);
+}
+
+#[test]
+fn given_supply_when_on_then_output_1() {
+    let mut chip = SupplyChip::new();
+    chip.turn_on();
     assert_eq!(chip.read_pin(0), 1);
 }
 
@@ -28,14 +35,6 @@ fn given_supply_when_off_then_output_0() {
     let mut chip = SupplyChip::new();
     chip.turn_off();
     assert_eq!(chip.read_pin(0), 0);
-}
-
-#[test]
-fn given_supply_when_on_then_output_1() {
-    let mut chip = SupplyChip::new();
-    chip.turn_off();
-    chip.turn_on();
-    assert_eq!(chip.read_pin(0), 1);
 }
 
 #[test]

--- a/src/chip/tests/test_circuit.rs
+++ b/src/chip/tests/test_circuit.rs
@@ -22,14 +22,11 @@
 // [ ] If a Trace intersects multiple Output Pins it is invalid.
 // [ ] Circuits are invalid if any Trace is invalid.
 // [ ] Compilation turns Traces into Links in the ChipDescription.
-// [ ] Circuits can be ticked, even if invalid.
 // [ ] Ticking a Circuit calls tick on all Chips with no Input pins connected to an invalid Trace.
 // [ ] Before a Chip is ticked, its Inputs are set to the values of the connected Traces.
 // [ ] After a Chip is ticked, Traces connected to its Outputs have their value set.
 // [ ] After a Circuit is ticked, all output Chips have their values set to the value of the connected Traces.
 // [ ] Trace states can be read from a Circuit.
-// [ ] All Chip Pin states can be read from a Circuit.
-// [ ] CircuitDescription can be read from a Circuit.
 // [ ] Circuit can be constructed from a ChipDescription.
 
 use crate::{chip::{

--- a/src/chip/tests/test_circuit.rs
+++ b/src/chip/tests/test_circuit.rs
@@ -33,7 +33,7 @@
 // [ ] Circuit can be constructed from a ChipDescription.
 
 use crate::{chip::{
-    chip::{Chip, CustomChip, GroundChip, InputChip, NAndChip, OutputChip, SupplyChip, Tickable}, chip_description::ChipDescription, circuit::Circuit, compiler::ChipCompiler, types::*
+    chip::{Chip, CustomChip, GroundChip, InputChip, NAndChip, OutputChip, SupplyChip, Tickable}, chip_description::ChipDescription, circuit::{self, Circuit}, compiler::ChipCompiler, types::*
 }, chip_pin};
 
 
@@ -50,6 +50,7 @@ fn given_supply_connected_then_output_is_1() {
     let mut circuit = Circuit::new();
     let supply_id = circuit.add_chip(SupplyChip::new());
     let output_id = circuit.add_chip(OutputChip::new());
+    circuit.set_supply(supply_id, 1);
     circuit.create_link(chip_pin!(supply_id, 0), chip_pin!(output_id, 0));
     circuit.tick();
     assert_eq!(circuit.get_output(output_id), 1);
@@ -60,6 +61,7 @@ fn given_supply_disconnected_then_output_is_0() {
     let mut circuit = Circuit::new();
     let supply_id = circuit.add_chip(SupplyChip::new());
     let output_id = circuit.add_chip(OutputChip::new());
+    circuit.set_supply(supply_id, 1);
     circuit.create_link(chip_pin!(supply_id, 0), chip_pin!(output_id, 0));
     circuit.tick();
     circuit.delete_link(chip_pin!(supply_id, 0), chip_pin!(output_id, 0));
@@ -111,19 +113,39 @@ fn given_input_connected_when_1_then_output_is_1() {
 }
 
 #[test]
+fn given_nand_when_supply_1_then_output_pin_1() {
+    println!("{:?}", NAndChip::new().get_description());
+
+    let mut circuit = Circuit::new();
+    let ground = circuit.add_chip(GroundChip::new());
+    let supply = circuit.add_chip(SupplyChip::new());
+    let nand = circuit.add_custom_chip(NAndChip::new());
+    circuit.create_link(chip_pin!(ground, 0), chip_pin!(nand, 0));
+    circuit.create_link(chip_pin!(supply, 0), chip_pin!(nand, 1));
+    circuit.set_supply(supply, 1);
+    circuit.tick();
+    let pin_states = circuit.get_chip_pin_states();
+    let output_pin_value = pin_states.get(&chip_pin!(nand, 4)).unwrap();
+    assert_eq!(*output_pin_value, 1);
+}
+
+#[test]
 fn given_not_gate_when_input_0_then_output_1() {
     let mut circuit = Circuit::new();
+    let ground = circuit.add_chip(GroundChip::new());
+    let supply = circuit.add_chip(SupplyChip::new());
     let input_id = circuit.add_chip(InputChip::new());
-
-    let mut chip = NAndChip::new();
-    chip.write_pin(chip.get_supply_pin(), 1);
-    let nand_id = circuit.add_custom_chip(chip);
-    
+    let nand_id = circuit.add_custom_chip(NAndChip::new());    
     let output_id = circuit.add_chip(OutputChip::new());
-    circuit.set_input(input_id, 0);
+
+    circuit.create_link(chip_pin!(ground, 0), chip_pin!(nand_id, 0));
+    circuit.create_link(chip_pin!(supply, 0), chip_pin!(nand_id, 1));
     circuit.create_link(chip_pin!(input_id, 0), chip_pin!(nand_id, 2));
     circuit.create_link(chip_pin!(input_id, 0), chip_pin!(nand_id, 3));
     circuit.create_link(chip_pin!(nand_id, 4), chip_pin!(output_id, 0));
+
+    circuit.set_supply(supply, 1);
+    circuit.set_input(input_id, 0);
     circuit.tick();
     assert_eq!(circuit.get_output(output_id), 1);
 }
@@ -131,17 +153,20 @@ fn given_not_gate_when_input_0_then_output_1() {
 #[test]
 fn given_not_gate_when_input_1_then_output_0() {
     let mut circuit = Circuit::new();
+    let ground = circuit.add_chip(GroundChip::new());
+    let supply = circuit.add_chip(SupplyChip::new());
     let input_id = circuit.add_chip(InputChip::new());
-
-    let mut chip = NAndChip::new();
-    chip.write_pin(chip.get_supply_pin(), 1);
-    let nand_id = circuit.add_custom_chip(chip);
-    
+    let nand_id = circuit.add_custom_chip(NAndChip::new());    
     let output_id = circuit.add_chip(OutputChip::new());
-    circuit.set_input(input_id, 1);
+
+    circuit.create_link(chip_pin!(ground, 0), chip_pin!(nand_id, 0));
+    circuit.create_link(chip_pin!(supply, 0), chip_pin!(nand_id, 1));
     circuit.create_link(chip_pin!(input_id, 0), chip_pin!(nand_id, 2));
     circuit.create_link(chip_pin!(input_id, 0), chip_pin!(nand_id, 3));
     circuit.create_link(chip_pin!(nand_id, 4), chip_pin!(output_id, 0));
+
+    circuit.set_supply(supply, 1);
+    circuit.set_input(input_id, 1);
     circuit.tick();
     assert_eq!(circuit.get_output(output_id), 0);
 }
@@ -175,7 +200,7 @@ fn given_compiled_not_circuit_then_functions_as_not_chip() {
 }
 
 
-fn compile_xor_chip() -> CustomChip {
+fn build_xor() -> (Circuit, usize, usize, usize) {
     let mut circuit = Circuit::new();
     let ground = circuit.add_chip(GroundChip::new());
     let supply = circuit.add_chip(SupplyChip::new());
@@ -210,15 +235,57 @@ fn compile_xor_chip() -> CustomChip {
 
     circuit.create_link(chip_pin!(nand_4, 4), chip_pin!(output, 0));
     
-    let description: ChipDescription = ChipCompiler::compile(circuit.get_description());
-
-    CustomChip::new(description)
+    return (circuit, in_a, in_b, output);
 }
 
+#[test]
+fn given_xor_when_both_inputs_0_then_output_0() {
+    let (mut circuit, in_a, in_b, output) = build_xor();
+    circuit.set_supply(circuit.get_supply_ids()[0], 1);
+
+    circuit.set_input(in_a, 0);
+    circuit.set_input(in_b, 0);
+    circuit.tick();
+    circuit.tick();
+    assert_eq!(circuit.get_output(output), 0);
+}
+
+#[test]
+fn given_xor_when_inputs_differ_then_output_1() {
+    let (mut circuit, in_a, in_b, output) = build_xor();
+    circuit.set_supply(circuit.get_supply_ids()[0], 1);
+
+    circuit.set_input(in_a, 1);
+    circuit.set_input(in_b, 0);
+    circuit.tick();
+    circuit.tick();
+    assert_eq!(circuit.get_output(output), 1);
+
+    circuit.set_input(in_a, 1);
+    circuit.set_input(in_b, 0);
+    circuit.tick();
+    circuit.tick();
+    assert_eq!(circuit.get_output(output), 1);
+}
+
+#[test]
+fn given_xor_when_both_inputs_1_then_output_0() {
+    let (mut circuit, in_a, in_b, output) = build_xor();
+    circuit.set_supply(circuit.get_supply_ids()[0], 1);
+
+    circuit.set_input(in_a, 1);
+    circuit.set_input(in_b, 1);
+    circuit.tick();
+    circuit.tick();
+    assert_eq!(circuit.get_output(output), 0);
+}
 
 #[test]
 fn given_compiled_xor_when_both_inputs_0_then_output_0() {
-    let mut xor = compile_xor_chip();
+    let (circuit, _, _, _) = build_xor();
+    let description: ChipDescription = ChipCompiler::compile(circuit.get_description());
+    let mut xor = CustomChip::new(description);
+
     let layout = xor.get_description().get_layout();
     xor.write_pin(xor.get_supply_pin(), 1);
 
@@ -231,7 +298,10 @@ fn given_compiled_xor_when_both_inputs_0_then_output_0() {
 
 #[test]
 fn given_compiled_xor_when_inputs_differ_then_output_1() {
-    let mut xor = compile_xor_chip();
+    let (circuit, _, _, _) = build_xor();
+    let description: ChipDescription = ChipCompiler::compile(circuit.get_description());
+    let mut xor = CustomChip::new(description);
+
     let layout = xor.get_description().get_layout();
     xor.write_pin(xor.get_supply_pin(), 1);
 
@@ -250,7 +320,10 @@ fn given_compiled_xor_when_inputs_differ_then_output_1() {
 
 #[test]
 fn given_compiled_xor_when_both_inputs_1_then_output_0() {
-    let mut xor = compile_xor_chip();
+    let (circuit, _, _, _) = build_xor();
+    let description: ChipDescription = ChipCompiler::compile(circuit.get_description());
+    let mut xor = CustomChip::new(description);
+
     let layout = xor.get_description().get_layout();
     xor.write_pin(xor.get_supply_pin(), 1);
 
@@ -259,4 +332,31 @@ fn given_compiled_xor_when_both_inputs_1_then_output_0() {
     xor.tick();
     xor.tick();
     assert_eq!(xor.read_pin(layout.output_pins[0]), 0);
+}
+
+#[test]
+fn given_xor_when_not_yet_ticked_then_all_pin_states_low() {
+    let (circuit, _, _, _) = build_xor();
+    let pin_states = circuit.get_chip_pin_states();
+    let all_low = pin_states.iter().all(|(_, value)| *value == 0);
+    assert!(all_low);
+}
+
+#[test]
+fn given_xor_when_supply_off_then_all_pin_states_low() {
+    let (mut circuit, _, _, _) = build_xor();
+    circuit.tick();
+    let pin_states = circuit.get_chip_pin_states();
+    let all_low = pin_states.iter().all(|(_, value)| *value == 0);
+    assert!(all_low);
+}
+
+#[test]
+fn given_xor_when_supply_on_then_pin_states_correct() {
+    let (mut circuit, _, _, _) = build_xor();
+    let supply_id = circuit.get_supply_ids()[0];
+    circuit.set_supply(supply_id, 1);
+    circuit.tick();
+    let pin_states = circuit.get_chip_pin_states();
+    println!("{:#?}", pin_states);
 }

--- a/src/chip/tests/test_circuit.rs
+++ b/src/chip/tests/test_circuit.rs
@@ -33,7 +33,7 @@
 // [ ] Circuit can be constructed from a ChipDescription.
 
 use crate::{chip::{
-    chip::{Chip, CustomChip, GroundChip, InputChip, NAndChip, OutputChip, SupplyChip, Tickable}, chip_description::ChipDescription, circuit::{self, Circuit}, compiler::ChipCompiler, types::*
+    chip::{Chip, CustomChip, GroundChip, InputChip, NAndChip, OutputChip, SupplyChip, Tickable}, chip_description::ChipDescription, circuit::Circuit, compiler::ChipCompiler, types::*
 }, chip_pin};
 
 
@@ -129,8 +129,7 @@ fn given_nand_when_supply_1_then_output_pin_1() {
     assert_eq!(*output_pin_value, 1);
 }
 
-#[test]
-fn given_not_gate_when_input_0_then_output_1() {
+fn build_not() -> (Circuit, usize, usize, usize) {
     let mut circuit = Circuit::new();
     let ground = circuit.add_chip(GroundChip::new());
     let supply = circuit.add_chip(SupplyChip::new());
@@ -144,6 +143,12 @@ fn given_not_gate_when_input_0_then_output_1() {
     circuit.create_link(chip_pin!(input_id, 0), chip_pin!(nand_id, 3));
     circuit.create_link(chip_pin!(nand_id, 4), chip_pin!(output_id, 0));
 
+    return (circuit, supply, input_id, output_id);
+}
+
+#[test]
+fn given_not_gate_when_input_0_then_output_1() {
+    let (mut circuit, supply, input_id, output_id) = build_not();
     circuit.set_supply(supply, 1);
     circuit.set_input(input_id, 0);
     circuit.tick();
@@ -152,19 +157,7 @@ fn given_not_gate_when_input_0_then_output_1() {
 
 #[test]
 fn given_not_gate_when_input_1_then_output_0() {
-    let mut circuit = Circuit::new();
-    let ground = circuit.add_chip(GroundChip::new());
-    let supply = circuit.add_chip(SupplyChip::new());
-    let input_id = circuit.add_chip(InputChip::new());
-    let nand_id = circuit.add_custom_chip(NAndChip::new());    
-    let output_id = circuit.add_chip(OutputChip::new());
-
-    circuit.create_link(chip_pin!(ground, 0), chip_pin!(nand_id, 0));
-    circuit.create_link(chip_pin!(supply, 0), chip_pin!(nand_id, 1));
-    circuit.create_link(chip_pin!(input_id, 0), chip_pin!(nand_id, 2));
-    circuit.create_link(chip_pin!(input_id, 0), chip_pin!(nand_id, 3));
-    circuit.create_link(chip_pin!(nand_id, 4), chip_pin!(output_id, 0));
-
+    let (mut circuit, supply, input_id, output_id) = build_not();
     circuit.set_supply(supply, 1);
     circuit.set_input(input_id, 1);
     circuit.tick();
@@ -173,18 +166,7 @@ fn given_not_gate_when_input_1_then_output_0() {
 
 #[test]
 fn given_compiled_not_circuit_then_functions_as_not_chip() {
-    let mut circuit = Circuit::new();
-    let ground_id = circuit.add_chip(GroundChip::new());
-    let supply_id = circuit.add_chip(SupplyChip::new());
-    let input_id = circuit.add_chip(InputChip::new());
-    let nand_id = circuit.add_custom_chip(NAndChip::new());
-    let output_id = circuit.add_chip(OutputChip::new());
-    circuit.create_link(chip_pin!(ground_id, 0), chip_pin!(nand_id, 0));
-    circuit.create_link(chip_pin!(supply_id, 0), chip_pin!(nand_id, 1));
-    circuit.create_link(chip_pin!(input_id, 0), chip_pin!(nand_id, 2));
-    circuit.create_link(chip_pin!(input_id, 0), chip_pin!(nand_id, 3));
-    circuit.create_link(chip_pin!(nand_id, 4), chip_pin!(output_id, 0));
-    
+    let (circuit, _, _, _) = build_not();    
     let description: ChipDescription = ChipCompiler::compile(circuit.get_description());
 
     let mut chip = CustomChip::new(description);
@@ -357,6 +339,44 @@ fn given_xor_when_supply_on_then_pin_states_correct() {
     let supply_id = circuit.get_supply_ids()[0];
     circuit.set_supply(supply_id, 1);
     circuit.tick();
-    let pin_states = circuit.get_chip_pin_states();
-    println!("{:#?}", pin_states);
+    let states = circuit.get_chip_pin_states();
+
+    // Ground and Supply
+    assert_eq!(*states.get(&chip_pin!(0, 0)).unwrap(), 0);
+    assert_eq!(*states.get(&chip_pin!(1, 0)).unwrap(), 1);
+
+    // Inputs
+    assert_eq!(*states.get(&chip_pin!(2, 0)).unwrap(), 0);
+    assert_eq!(*states.get(&chip_pin!(3, 0)).unwrap(), 0);
+
+    // NAnd 1
+    assert_eq!(*states.get(&chip_pin!(4, 0)).unwrap(), 0);
+    assert_eq!(*states.get(&chip_pin!(4, 1)).unwrap(), 1);
+    assert_eq!(*states.get(&chip_pin!(4, 2)).unwrap(), 0);
+    assert_eq!(*states.get(&chip_pin!(4, 3)).unwrap(), 0);
+    assert_eq!(*states.get(&chip_pin!(4, 4)).unwrap(), 1);
+
+    // NAnd 2
+    assert_eq!(*states.get(&chip_pin!(5, 0)).unwrap(), 0);
+    assert_eq!(*states.get(&chip_pin!(5, 1)).unwrap(), 1);
+    assert_eq!(*states.get(&chip_pin!(5, 2)).unwrap(), 0);
+    assert_eq!(*states.get(&chip_pin!(5, 3)).unwrap(), 1);
+    assert_eq!(*states.get(&chip_pin!(5, 4)).unwrap(), 1);
+
+    // NAnd 3
+    assert_eq!(*states.get(&chip_pin!(6, 0)).unwrap(), 0);
+    assert_eq!(*states.get(&chip_pin!(6, 1)).unwrap(), 1);
+    assert_eq!(*states.get(&chip_pin!(6, 2)).unwrap(), 0);
+    assert_eq!(*states.get(&chip_pin!(6, 3)).unwrap(), 1);
+    assert_eq!(*states.get(&chip_pin!(6, 4)).unwrap(), 1);
+
+    // NAnd 4
+    assert_eq!(*states.get(&chip_pin!(7, 0)).unwrap(), 0);
+    assert_eq!(*states.get(&chip_pin!(7, 1)).unwrap(), 1);
+    assert_eq!(*states.get(&chip_pin!(7, 2)).unwrap(), 1);
+    assert_eq!(*states.get(&chip_pin!(7, 3)).unwrap(), 1);
+    assert_eq!(*states.get(&chip_pin!(7, 4)).unwrap(), 0);
+
+    // Output
+    assert_eq!(*states.get(&chip_pin!(8, 0)).unwrap(), 0);
 }


### PR DESCRIPTION
![Builds](https://github.com/harvey-cash/a-bit-rusty/actions/workflows/build.yml/badge.svg?event=pull_request) ![Tests](https://github.com/harvey-cash/a-bit-rusty/actions/workflows/test.yml/badge.svg?event=pull_request) ![Coverage](https://img.shields.io/endpoint?style=flat-square&url=https%3A%2F%2Fgist.githubusercontent.com%2Fharvey-cash%2Fba441ef05e0a64327d9a24b5d526d08a%2Fraw%2Fa-bit-rusty-cobertura-coverage.json)

### Description

Previously only digital input pins were being set. Now ground and supply get set too.
SupplyChip now defaults to off.
Pin states can be read from a Circuit.
